### PR TITLE
Update tooling to remove authentication and consent related headers

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
     hooks:
       - id: shellcheck
   - repo: https://github.com/ioxio-dataspace/ioxio-data-product-definition-tooling
-    rev: 0.16.0
+    rev: 0.17.0
     hooks:
       - id: data-product-definition-converter
         # TODO: convert only the file that was changed
@@ -54,7 +54,7 @@ repos:
         files: ".*?DataProducts/.*?json$"
         args: ["--path", "./DataProducts"]
   - repo: https://github.com/ioxio-dataspace/ioxio-data-product-definition-tooling
-    rev: 0.16.0
+    rev: 0.17.0
     hooks:
       - id: data-product-definition-validator
         files: ".*?DataProducts/.*?json$"

--- a/DataProducts/Employment/EscoOccupations_v0.1.json
+++ b/DataProducts/Employment/EscoOccupations_v0.1.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Employment ESCO Occupations",
     "description": "Returns the list of standardized occupations based on the European Standard Classification of Occupations (ESCO) version 1.1.1",
-    "version": "0.1.1"
+    "version": "0.1.2"
   },
   "paths": {
     "/Employment/EscoOccupations_v0.1": {
@@ -13,48 +13,6 @@
         "operationId": "request_Employment_EscoOccupations_v0_1",
         "deprecated": true,
         "parameters": [
-          {
-            "name": "x-consent-token",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "description": "Optional consent token",
-              "default": "",
-              "title": "X-Consent-Token"
-            },
-            "description": "Optional consent token"
-          },
-          {
-            "name": "authorization",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "description": "The login token. Value should be \"Bearer [token]\"",
-              "default": "",
-              "title": "Authorization"
-            },
-            "description": "The login token. Value should be \"Bearer [token]\""
-          },
-          {
-            "name": "x-authorization-provider",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "The bare domain of the system that provided the token.",
-              "title": "X-Authorization-Provider"
-            },
-            "description": "The bare domain of the system that provided the token."
-          },
           {
             "name": "x-api-key",
             "in": "header",

--- a/DataProducts/Employment/EscoOccupations_v1.0.json
+++ b/DataProducts/Employment/EscoOccupations_v1.0.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Employment ESCO Occupations",
     "description": "Returns the list of standardized occupations based on the European Standard Classification of Occupations (ESCO) version 1.1.1",
-    "version": "1.0.1"
+    "version": "1.0.2"
   },
   "paths": {
     "/Employment/EscoOccupations_v1.0": {
@@ -12,48 +12,6 @@
         "description": "Returns the list of standardized occupations based on the European Standard Classification of Occupations (ESCO) version 1.1.1",
         "operationId": "request_Employment_EscoOccupations_v1_0",
         "parameters": [
-          {
-            "name": "x-consent-token",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "description": "Optional consent token",
-              "default": "",
-              "title": "X-Consent-Token"
-            },
-            "description": "Optional consent token"
-          },
-          {
-            "name": "authorization",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "description": "The login token. Value should be \"Bearer [token]\"",
-              "default": "",
-              "title": "Authorization"
-            },
-            "description": "The login token. Value should be \"Bearer [token]\""
-          },
-          {
-            "name": "x-authorization-provider",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "The bare domain of the system that provided the token.",
-              "title": "X-Authorization-Provider"
-            },
-            "description": "The bare domain of the system that provided the token."
-          },
           {
             "name": "x-api-key",
             "in": "header",

--- a/DataProducts/Employment/ForeignerJobRecommendations_v0.4.json
+++ b/DataProducts/Employment/ForeignerJobRecommendations_v0.4.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Foreigner Job Recommendations",
     "description": "Returns the list of jobs recommended for the foreigner based on e.g. the citizenship area and previous occupations based on the European Standard Classification of Occupations (ESCO) version 1.1.1",
-    "version": "0.4.1"
+    "version": "0.4.2"
   },
   "paths": {
     "/Employment/ForeignerJobRecommendations_v0.4": {
@@ -12,48 +12,6 @@
         "description": "Returns the list of jobs recommended for the foreigner based on e.g. the citizenship area and previous occupations based on the European Standard Classification of Occupations (ESCO) version 1.1.1",
         "operationId": "request_Employment_ForeignerJobRecommendations_v0_4",
         "parameters": [
-          {
-            "name": "x-consent-token",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "description": "Optional consent token",
-              "default": "",
-              "title": "X-Consent-Token"
-            },
-            "description": "Optional consent token"
-          },
-          {
-            "name": "authorization",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "description": "The login token. Value should be \"Bearer [token]\"",
-              "default": "",
-              "title": "Authorization"
-            },
-            "description": "The login token. Value should be \"Bearer [token]\""
-          },
-          {
-            "name": "x-authorization-provider",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "The bare domain of the system that provided the token.",
-              "title": "X-Authorization-Provider"
-            },
-            "description": "The bare domain of the system that provided the token."
-          },
           {
             "name": "x-api-key",
             "in": "header",

--- a/DataProducts/NSG/Agent/BasicInformation_v1.0.json
+++ b/DataProducts/NSG/Agent/BasicInformation_v1.0.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "NSG Agent information",
     "description": "In the Nordic Smart Government information exchange context the agent represents both registered organizations (\"companies\") and persons who are doing business without being registered organizations, usually as sole traders (sole proprietors). This data product definition returns basic information content for any agent.",
-    "version": "1.0.1"
+    "version": "1.0.2"
   },
   "paths": {
     "/NSG/Agent/BasicInformation_v1.0": {
@@ -12,48 +12,6 @@
         "description": "In the Nordic Smart Government information exchange context the agent represents both registered organizations (\"companies\") and persons who are doing business without being registered organizations, usually as sole traders (sole proprietors). This data product definition returns basic information content for any agent.",
         "operationId": "request_NSG_Agent_BasicInformation_v1_0",
         "parameters": [
-          {
-            "name": "x-consent-token",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "description": "Optional consent token",
-              "default": "",
-              "title": "X-Consent-Token"
-            },
-            "description": "Optional consent token"
-          },
-          {
-            "name": "authorization",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "description": "The login token. Value should be \"Bearer [token]\"",
-              "default": "",
-              "title": "Authorization"
-            },
-            "description": "The login token. Value should be \"Bearer [token]\""
-          },
-          {
-            "name": "x-authorization-provider",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "The bare domain of the system that provided the token.",
-              "title": "X-Authorization-Provider"
-            },
-            "description": "The bare domain of the system that provided the token."
-          },
           {
             "name": "x-api-key",
             "in": "header",

--- a/DataProducts/Person/BasicInformation/Write_v0.1.json
+++ b/DataProducts/Person/BasicInformation/Write_v0.1.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Write Person Basic Information",
     "description": "Create or update a minimal set of basic information of a person",
-    "version": "0.1.1"
+    "version": "0.1.2"
   },
   "paths": {
     "/Person/BasicInformation/Write_v0.1": {
@@ -13,46 +13,6 @@
         "operationId": "request_Person_BasicInformation_Write_v0_1",
         "deprecated": true,
         "parameters": [
-          {
-            "name": "x-consent-token",
-            "in": "header",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "description": "Consent token",
-              "title": "X-Consent-Token"
-            },
-            "description": "Consent token"
-          },
-          {
-            "name": "authorization",
-            "in": "header",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "description": "The login token. Value should be \"Bearer [token]\"",
-              "title": "Authorization"
-            },
-            "description": "The login token. Value should be \"Bearer [token]\""
-          },
-          {
-            "name": "x-authorization-provider",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "The bare domain of the system that provided the token.",
-              "title": "X-Authorization-Provider"
-            },
-            "description": "The bare domain of the system that provided the token."
-          },
           {
             "name": "x-api-key",
             "in": "header",

--- a/DataProducts/Person/BasicInformation/Write_v1.0.json
+++ b/DataProducts/Person/BasicInformation/Write_v1.0.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Write Person Basic Information",
     "description": "Create or update a minimal set of basic information of a person",
-    "version": "1.0.1"
+    "version": "1.0.2"
   },
   "paths": {
     "/Person/BasicInformation/Write_v1.0": {
@@ -11,47 +11,8 @@
         "summary": "Write Person Basic Information",
         "description": "Create or update a minimal set of basic information of a person",
         "operationId": "request_Person_BasicInformation_Write_v1_0",
+        "deprecated": true,
         "parameters": [
-          {
-            "name": "x-consent-token",
-            "in": "header",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "description": "Consent token",
-              "title": "X-Consent-Token"
-            },
-            "description": "Consent token"
-          },
-          {
-            "name": "authorization",
-            "in": "header",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "description": "The login token. Value should be \"Bearer [token]\"",
-              "title": "Authorization"
-            },
-            "description": "The login token. Value should be \"Bearer [token]\""
-          },
-          {
-            "name": "x-authorization-provider",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "The bare domain of the system that provided the token.",
-              "title": "X-Authorization-Provider"
-            },
-            "description": "The bare domain of the system that provided the token."
-          },
           {
             "name": "x-api-key",
             "in": "header",

--- a/DataProducts/Person/BasicInformation/Write_v2.0.json
+++ b/DataProducts/Person/BasicInformation/Write_v2.0.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Write Person Basic Information",
     "description": "Create or update a minimal set of basic information of a person",
-    "version": "2.0.1"
+    "version": "2.0.2"
   },
   "paths": {
     "/Person/BasicInformation/Write_v2.0": {
@@ -12,46 +12,6 @@
         "description": "Create or update a minimal set of basic information of a person",
         "operationId": "request_Person_BasicInformation_Write_v2_0",
         "parameters": [
-          {
-            "name": "x-consent-token",
-            "in": "header",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "description": "Consent token",
-              "title": "X-Consent-Token"
-            },
-            "description": "Consent token"
-          },
-          {
-            "name": "authorization",
-            "in": "header",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "description": "The login token. Value should be \"Bearer [token]\"",
-              "title": "Authorization"
-            },
-            "description": "The login token. Value should be \"Bearer [token]\""
-          },
-          {
-            "name": "x-authorization-provider",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "The bare domain of the system that provided the token.",
-              "title": "X-Authorization-Provider"
-            },
-            "description": "The bare domain of the system that provided the token."
-          },
           {
             "name": "x-api-key",
             "in": "header",

--- a/DataProducts/Person/BasicInformation/Write_v2.0.json
+++ b/DataProducts/Person/BasicInformation/Write_v2.0.json
@@ -11,6 +11,7 @@
         "summary": "Write Person Basic Information",
         "description": "Create or update a minimal set of basic information of a person",
         "operationId": "request_Person_BasicInformation_Write_v2_0",
+        "deprecated": true,
         "parameters": [
           {
             "name": "x-api-key",

--- a/DataProducts/Person/BasicInformation_v0.1.json
+++ b/DataProducts/Person/BasicInformation_v0.1.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Person Basic Information",
     "description": "A minimal set of basic information of a person",
-    "version": "0.1.1"
+    "version": "0.1.2"
   },
   "paths": {
     "/Person/BasicInformation_v0.1": {
@@ -13,46 +13,6 @@
         "operationId": "request_Person_BasicInformation_v0_1",
         "deprecated": true,
         "parameters": [
-          {
-            "name": "x-consent-token",
-            "in": "header",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "description": "Consent token",
-              "title": "X-Consent-Token"
-            },
-            "description": "Consent token"
-          },
-          {
-            "name": "authorization",
-            "in": "header",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "description": "The login token. Value should be \"Bearer [token]\"",
-              "title": "Authorization"
-            },
-            "description": "The login token. Value should be \"Bearer [token]\""
-          },
-          {
-            "name": "x-authorization-provider",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "The bare domain of the system that provided the token.",
-              "title": "X-Authorization-Provider"
-            },
-            "description": "The bare domain of the system that provided the token."
-          },
           {
             "name": "x-api-key",
             "in": "header",

--- a/DataProducts/Person/BasicInformation_v1.0.json
+++ b/DataProducts/Person/BasicInformation_v1.0.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Person Basic Information",
     "description": "A minimal set of basic information of a person",
-    "version": "1.0.1"
+    "version": "1.0.2"
   },
   "paths": {
     "/Person/BasicInformation_v1.0": {
@@ -11,47 +11,8 @@
         "summary": "Person Basic Information",
         "description": "A minimal set of basic information of a person",
         "operationId": "request_Person_BasicInformation_v1_0",
+        "deprecated": true,
         "parameters": [
-          {
-            "name": "x-consent-token",
-            "in": "header",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "description": "Consent token",
-              "title": "X-Consent-Token"
-            },
-            "description": "Consent token"
-          },
-          {
-            "name": "authorization",
-            "in": "header",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "description": "The login token. Value should be \"Bearer [token]\"",
-              "title": "Authorization"
-            },
-            "description": "The login token. Value should be \"Bearer [token]\""
-          },
-          {
-            "name": "x-authorization-provider",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "The bare domain of the system that provided the token.",
-              "title": "X-Authorization-Provider"
-            },
-            "description": "The bare domain of the system that provided the token."
-          },
           {
             "name": "x-api-key",
             "in": "header",

--- a/DataProducts/Person/BasicInformation_v2.0.json
+++ b/DataProducts/Person/BasicInformation_v2.0.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Person Basic Information",
     "description": "A minimal set of basic information of a person",
-    "version": "2.0.1"
+    "version": "2.0.2"
   },
   "paths": {
     "/Person/BasicInformation_v2.0": {
@@ -12,46 +12,6 @@
         "description": "A minimal set of basic information of a person",
         "operationId": "request_Person_BasicInformation_v2_0",
         "parameters": [
-          {
-            "name": "x-consent-token",
-            "in": "header",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "description": "Consent token",
-              "title": "X-Consent-Token"
-            },
-            "description": "Consent token"
-          },
-          {
-            "name": "authorization",
-            "in": "header",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "description": "The login token. Value should be \"Bearer [token]\"",
-              "title": "Authorization"
-            },
-            "description": "The login token. Value should be \"Bearer [token]\""
-          },
-          {
-            "name": "x-authorization-provider",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "The bare domain of the system that provided the token.",
-              "title": "X-Authorization-Provider"
-            },
-            "description": "The bare domain of the system that provided the token."
-          },
           {
             "name": "x-api-key",
             "in": "header",

--- a/DataProducts/Person/JobApplicantProfile/Write_v0.1.json
+++ b/DataProducts/Person/JobApplicantProfile/Write_v0.1.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Write Person Job Applicant Profile",
     "description": "Create or update a comprehensive set of skills, competences, occupations and work preferences of a person",
-    "version": "0.1.1"
+    "version": "0.1.2"
   },
   "paths": {
     "/Person/JobApplicantProfile/Write_v0.1": {
@@ -13,46 +13,6 @@
         "operationId": "request_Person_JobApplicantProfile_Write_v0_1",
         "deprecated": true,
         "parameters": [
-          {
-            "name": "x-consent-token",
-            "in": "header",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "description": "Consent token",
-              "title": "X-Consent-Token"
-            },
-            "description": "Consent token"
-          },
-          {
-            "name": "authorization",
-            "in": "header",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "description": "The login token. Value should be \"Bearer [token]\"",
-              "title": "Authorization"
-            },
-            "description": "The login token. Value should be \"Bearer [token]\""
-          },
-          {
-            "name": "x-authorization-provider",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "The bare domain of the system that provided the token.",
-              "title": "X-Authorization-Provider"
-            },
-            "description": "The bare domain of the system that provided the token."
-          },
           {
             "name": "x-api-key",
             "in": "header",

--- a/DataProducts/Person/JobApplicantProfile/Write_v1.0.json
+++ b/DataProducts/Person/JobApplicantProfile/Write_v1.0.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Write Person Job Applicant Profile",
     "description": "Create or update a comprehensive set of skills, competences, occupations and work preferences of a person",
-    "version": "1.0.1"
+    "version": "1.0.2"
   },
   "paths": {
     "/Person/JobApplicantProfile/Write_v1.0": {
@@ -11,47 +11,8 @@
         "summary": "Write Person Job Applicant Profile",
         "description": "Create or update a comprehensive set of skills, competences, occupations and work preferences of a person",
         "operationId": "request_Person_JobApplicantProfile_Write_v1_0",
+        "deprecated": true,
         "parameters": [
-          {
-            "name": "x-consent-token",
-            "in": "header",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "description": "Consent token",
-              "title": "X-Consent-Token"
-            },
-            "description": "Consent token"
-          },
-          {
-            "name": "authorization",
-            "in": "header",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "description": "The login token. Value should be \"Bearer [token]\"",
-              "title": "Authorization"
-            },
-            "description": "The login token. Value should be \"Bearer [token]\""
-          },
-          {
-            "name": "x-authorization-provider",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "The bare domain of the system that provided the token.",
-              "title": "X-Authorization-Provider"
-            },
-            "description": "The bare domain of the system that provided the token."
-          },
           {
             "name": "x-api-key",
             "in": "header",

--- a/DataProducts/Person/JobApplicantProfile/Write_v2.0.json
+++ b/DataProducts/Person/JobApplicantProfile/Write_v2.0.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Write Person Job Applicant Profile",
     "description": "Create or update a comprehensive set of skills, competences, occupations and work preferences of a person",
-    "version": "2.0.1"
+    "version": "2.0.2"
   },
   "paths": {
     "/Person/JobApplicantProfile/Write_v2.0": {
@@ -11,47 +11,8 @@
         "summary": "Write Person Job Applicant Profile",
         "description": "Create or update a comprehensive set of skills, competences, occupations and work preferences of a person",
         "operationId": "request_Person_JobApplicantProfile_Write_v2_0",
+        "deprecated": true,
         "parameters": [
-          {
-            "name": "x-consent-token",
-            "in": "header",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "description": "Consent token",
-              "title": "X-Consent-Token"
-            },
-            "description": "Consent token"
-          },
-          {
-            "name": "authorization",
-            "in": "header",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "description": "The login token. Value should be \"Bearer [token]\"",
-              "title": "Authorization"
-            },
-            "description": "The login token. Value should be \"Bearer [token]\""
-          },
-          {
-            "name": "x-authorization-provider",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "The bare domain of the system that provided the token.",
-              "title": "X-Authorization-Provider"
-            },
-            "description": "The bare domain of the system that provided the token."
-          },
           {
             "name": "x-api-key",
             "in": "header",

--- a/DataProducts/Person/JobApplicantProfile_v0.1.json
+++ b/DataProducts/Person/JobApplicantProfile_v0.1.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Person Job Applicant Profile",
     "description": "A comprehensive set of skills, competences, occupations and work preferences of a person",
-    "version": "0.1.1"
+    "version": "0.1.2"
   },
   "paths": {
     "/Person/JobApplicantProfile_v0.1": {
@@ -13,46 +13,6 @@
         "operationId": "request_Person_JobApplicantProfile_v0_1",
         "deprecated": true,
         "parameters": [
-          {
-            "name": "x-consent-token",
-            "in": "header",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "description": "Consent token",
-              "title": "X-Consent-Token"
-            },
-            "description": "Consent token"
-          },
-          {
-            "name": "authorization",
-            "in": "header",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "description": "The login token. Value should be \"Bearer [token]\"",
-              "title": "Authorization"
-            },
-            "description": "The login token. Value should be \"Bearer [token]\""
-          },
-          {
-            "name": "x-authorization-provider",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "The bare domain of the system that provided the token.",
-              "title": "X-Authorization-Provider"
-            },
-            "description": "The bare domain of the system that provided the token."
-          },
           {
             "name": "x-api-key",
             "in": "header",

--- a/DataProducts/Person/JobApplicantProfile_v1.0.json
+++ b/DataProducts/Person/JobApplicantProfile_v1.0.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Person Job Applicant Profile",
     "description": "A comprehensive set of skills, competences, occupations and work preferences of a person",
-    "version": "1.0.1"
+    "version": "1.0.2"
   },
   "paths": {
     "/Person/JobApplicantProfile_v1.0": {
@@ -11,47 +11,8 @@
         "summary": "Person Job Applicant Profile",
         "description": "A comprehensive set of skills, competences, occupations and work preferences of a person",
         "operationId": "request_Person_JobApplicantProfile_v1_0",
+        "deprecated": true,
         "parameters": [
-          {
-            "name": "x-consent-token",
-            "in": "header",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "description": "Consent token",
-              "title": "X-Consent-Token"
-            },
-            "description": "Consent token"
-          },
-          {
-            "name": "authorization",
-            "in": "header",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "description": "The login token. Value should be \"Bearer [token]\"",
-              "title": "Authorization"
-            },
-            "description": "The login token. Value should be \"Bearer [token]\""
-          },
-          {
-            "name": "x-authorization-provider",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "The bare domain of the system that provided the token.",
-              "title": "X-Authorization-Provider"
-            },
-            "description": "The bare domain of the system that provided the token."
-          },
           {
             "name": "x-api-key",
             "in": "header",

--- a/DataProducts/Person/JobApplicantProfile_v2.0.json
+++ b/DataProducts/Person/JobApplicantProfile_v2.0.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Person Job Applicant Profile",
     "description": "A comprehensive set of skills, competences, occupations and work preferences of a person",
-    "version": "2.0.1"
+    "version": "2.0.2"
   },
   "paths": {
     "/Person/JobApplicantProfile_v2.0": {
@@ -11,47 +11,8 @@
         "summary": "Person Job Applicant Profile",
         "description": "A comprehensive set of skills, competences, occupations and work preferences of a person",
         "operationId": "request_Person_JobApplicantProfile_v2_0",
+        "deprecated": true,
         "parameters": [
-          {
-            "name": "x-consent-token",
-            "in": "header",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "description": "Consent token",
-              "title": "X-Consent-Token"
-            },
-            "description": "Consent token"
-          },
-          {
-            "name": "authorization",
-            "in": "header",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "description": "The login token. Value should be \"Bearer [token]\"",
-              "title": "Authorization"
-            },
-            "description": "The login token. Value should be \"Bearer [token]\""
-          },
-          {
-            "name": "x-authorization-provider",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "The bare domain of the system that provided the token.",
-              "title": "X-Authorization-Provider"
-            },
-            "description": "The bare domain of the system that provided the token."
-          },
           {
             "name": "x-api-key",
             "in": "header",

--- a/src/Employment/EscoOccupations_v0.1.py
+++ b/src/Employment/EscoOccupations_v0.1.py
@@ -3085,7 +3085,7 @@ class EscoOccupationResponse(CamelCaseModel):
 
 
 DEFINITION = DataProductDefinition(
-    version="0.1.1",
+    version="0.1.2",
     strict_validation=False,
     deprecated=True,
     title="Employment ESCO Occupations",
@@ -3093,6 +3093,4 @@ DEFINITION = DataProductDefinition(
     "Occupations (ESCO) version 1.1.1",
     request=EscoOccupationRequest,
     response=EscoOccupationResponse,
-    requires_authorization=False,
-    requires_consent=False,
 )

--- a/src/Employment/EscoOccupations_v1.0.py
+++ b/src/Employment/EscoOccupations_v1.0.py
@@ -3085,13 +3085,11 @@ class EscoOccupationResponse(CamelCaseModel):
 
 
 DEFINITION = DataProductDefinition(
-    version="1.0.1",
+    version="1.0.2",
     strict_validation=False,
     title="Employment ESCO Occupations",
     description="Returns the list of standardized occupations based on the European Standard Classification of "
     "Occupations (ESCO) version 1.1.1",
     request=EscoOccupationRequest,
     response=EscoOccupationResponse,
-    requires_authorization=False,
-    requires_consent=False,
 )

--- a/src/Employment/ForeignerJobRecommendations_v0.4.py
+++ b/src/Employment/ForeignerJobRecommendations_v0.4.py
@@ -472,7 +472,7 @@ class ForeignerJobRecommendationsResponse(CamelCaseModel):
 
 
 DEFINITION = DataProductDefinition(
-    version="0.4.1",
+    version="0.4.2",
     strict_validation=False,
     title="Foreigner Job Recommendations",
     description="Returns the list of jobs recommended for the foreigner based on e.g. "
@@ -480,6 +480,4 @@ DEFINITION = DataProductDefinition(
     "Classification of Occupations (ESCO) version 1.1.1",
     request=ForeignerJobRecommendationsRequest,
     response=ForeignerJobRecommendationsResponse,
-    requires_authorization=False,
-    requires_consent=False,
 )

--- a/src/NSG/Agent/BasicInformation_v1.0.py
+++ b/src/NSG/Agent/BasicInformation_v1.0.py
@@ -551,7 +551,7 @@ class BasicInformationResponse(CamelCaseModel):
 
 
 DEFINITION = DataProductDefinition(
-    version="1.0.1",
+    version="1.0.2",
     strict_validation=False,
     title="NSG Agent information",
     description="In the Nordic Smart Government information exchange context the agent "

--- a/src/Person/BasicInformation/Write_v0.1.py
+++ b/src/Person/BasicInformation/Write_v0.1.py
@@ -293,13 +293,11 @@ class BasicInformationRequestRequest(BasicInformationRequestResponse):
 
 
 DEFINITION = DataProductDefinition(
-    version="0.1.1",
+    version="0.1.2",
     deprecated=True,
     strict_validation=False,
     title="Write Person Basic Information",
     description="Create or update a minimal set of basic information of a person",
     request=BasicInformationRequestRequest,
     response=BasicInformationRequestResponse,
-    requires_authorization=True,
-    requires_consent=True,
 )

--- a/src/Person/BasicInformation/Write_v1.0.py
+++ b/src/Person/BasicInformation/Write_v1.0.py
@@ -290,12 +290,11 @@ class BasicInformationRequestResponse(CamelCaseModel):
 
 
 DEFINITION = DataProductDefinition(
-    version="1.0.1",
+    version="1.0.2",
     strict_validation=False,
+    deprecated=True,
     title="Write Person Basic Information",
     description="Create or update a minimal set of basic information of a person",
     request=BasicInformationRequestResponse,
     response=BasicInformationRequestResponse,
-    requires_authorization=True,
-    requires_consent=True,
 )

--- a/src/Person/BasicInformation/Write_v2.0.py
+++ b/src/Person/BasicInformation/Write_v2.0.py
@@ -50,6 +50,7 @@ class BasicInformationRequestResponse(CamelCaseModel):
 DEFINITION = DataProductDefinition(
     version="2.0.2",
     strict_validation=False,
+    deprecated=True,
     title="Write Person Basic Information",
     description="Create or update a minimal set of basic information of a person",
     request=BasicInformationRequestResponse,

--- a/src/Person/BasicInformation/Write_v2.0.py
+++ b/src/Person/BasicInformation/Write_v2.0.py
@@ -48,12 +48,10 @@ class BasicInformationRequestResponse(CamelCaseModel):
 
 
 DEFINITION = DataProductDefinition(
-    version="2.0.1",
+    version="2.0.2",
     strict_validation=False,
     title="Write Person Basic Information",
     description="Create or update a minimal set of basic information of a person",
     request=BasicInformationRequestResponse,
     response=BasicInformationRequestResponse,
-    requires_authorization=True,
-    requires_consent=True,
 )

--- a/src/Person/BasicInformation_v0.1.py
+++ b/src/Person/BasicInformation_v0.1.py
@@ -293,13 +293,11 @@ class BasicInformationResponse(CamelCaseModel):
 
 
 DEFINITION = DataProductDefinition(
-    version="0.1.1",
+    version="0.1.2",
     strict_validation=False,
     deprecated=True,
     title="Person Basic Information",
     description="A minimal set of basic information of a person",
     request=BasicInformationRequest,
     response=BasicInformationResponse,
-    requires_authorization=True,
-    requires_consent=True,
 )

--- a/src/Person/BasicInformation_v1.0.py
+++ b/src/Person/BasicInformation_v1.0.py
@@ -294,12 +294,11 @@ class BasicInformationResponse(CamelCaseModel):
 
 
 DEFINITION = DataProductDefinition(
-    version="1.0.1",
+    version="1.0.2",
     strict_validation=False,
+    deprecated=True,
     title="Person Basic Information",
     description="A minimal set of basic information of a person",
     request=BasicInformationRequest,
     response=BasicInformationResponse,
-    requires_authorization=True,
-    requires_consent=True,
 )

--- a/src/Person/BasicInformation_v2.0.py
+++ b/src/Person/BasicInformation_v2.0.py
@@ -52,12 +52,11 @@ class BasicInformationResponse(CamelCaseModel):
 
 
 DEFINITION = DataProductDefinition(
-    version="2.0.1",
+    version="2.0.2",
     strict_validation=False,
+    deprectaed=True,
     title="Person Basic Information",
     description="A minimal set of basic information of a person",
     request=BasicInformationRequest,
     response=BasicInformationResponse,
-    requires_authorization=True,
-    requires_consent=True,
 )

--- a/src/Person/JobApplicantProfile/Write_v0.1.py
+++ b/src/Person/JobApplicantProfile/Write_v0.1.py
@@ -5052,7 +5052,7 @@ class JobApplicantProfileRequestRequest(JobApplicantProfileRequestResponse):
 
 
 DEFINITION = DataProductDefinition(
-    version="0.1.1",
+    version="0.1.2",
     deprecated=True,
     strict_validation=False,
     title="Write Person Job Applicant Profile",
@@ -5060,6 +5060,4 @@ DEFINITION = DataProductDefinition(
     "occupations and work preferences of a person",
     request=JobApplicantProfileRequestRequest,
     response=JobApplicantProfileRequestResponse,
-    requires_authorization=True,
-    requires_consent=True,
 )

--- a/src/Person/JobApplicantProfile/Write_v1.0.py
+++ b/src/Person/JobApplicantProfile/Write_v1.0.py
@@ -5052,13 +5052,12 @@ class JobApplicantProfileRequestRequest(JobApplicantProfileRequestResponse):
 
 
 DEFINITION = DataProductDefinition(
-    version="1.0.1",
+    version="1.0.2",
     strict_validation=False,
+    deprecated=True,
     title="Write Person Job Applicant Profile",
     description="Create or update a comprehensive set of skills, competences, "
     "occupations and work preferences of a person",
     request=JobApplicantProfileRequestRequest,
     response=JobApplicantProfileRequestResponse,
-    requires_authorization=True,
-    requires_consent=True,
 )

--- a/src/Person/JobApplicantProfile/Write_v2.0.py
+++ b/src/Person/JobApplicantProfile/Write_v2.0.py
@@ -5063,13 +5063,12 @@ class JobApplicantProfileResponse(JobApplicantProfileRequest):
 
 
 DEFINITION = DataProductDefinition(
-    version="2.0.1",
+    version="2.0.2",
     strict_validation=False,
+    deprecated=True,
     title="Write Person Job Applicant Profile",
     description="Create or update a comprehensive set of skills, competences, "
     "occupations and work preferences of a person",
     request=JobApplicantProfileRequest,
     response=JobApplicantProfileResponse,
-    requires_authorization=True,
-    requires_consent=True,
 )

--- a/src/Person/JobApplicantProfile_v0.1.py
+++ b/src/Person/JobApplicantProfile_v0.1.py
@@ -5052,7 +5052,7 @@ class JobApplicantProfileResponse(CamelCaseModel):
 
 
 DEFINITION = DataProductDefinition(
-    version="0.1.1",
+    version="0.1.2",
     deprecated=True,
     strict_validation=False,
     title="Person Job Applicant Profile",
@@ -5060,6 +5060,4 @@ DEFINITION = DataProductDefinition(
     "preferences of a person",
     request=JobApplicantProfileRequest,
     response=JobApplicantProfileResponse,
-    requires_authorization=True,
-    requires_consent=True,
 )

--- a/src/Person/JobApplicantProfile_v1.0.py
+++ b/src/Person/JobApplicantProfile_v1.0.py
@@ -5052,13 +5052,12 @@ class JobApplicantProfileResponse(CamelCaseModel):
 
 
 DEFINITION = DataProductDefinition(
-    version="1.0.1",
+    version="1.0.2",
     strict_validation=False,
+    deprecated=True,
     title="Person Job Applicant Profile",
     description="A comprehensive set of skills, competences, occupations and work "
     "preferences of a person",
     request=JobApplicantProfileRequest,
     response=JobApplicantProfileResponse,
-    requires_authorization=True,
-    requires_consent=True,
 )

--- a/src/Person/JobApplicantProfile_v2.0.py
+++ b/src/Person/JobApplicantProfile_v2.0.py
@@ -5063,13 +5063,12 @@ class JobApplicantProfileResponse(CamelCaseModel):
 
 
 DEFINITION = DataProductDefinition(
-    version="2.0.1",
+    version="2.0.2",
     strict_validation=False,
+    deprecated=True,
     title="Person Job Applicant Profile",
     description="A comprehensive set of skills, competences, occupations and work "
     "preferences of a person",
     request=JobApplicantProfileRequest,
     response=JobApplicantProfileResponse,
-    requires_authorization=True,
-    requires_consent=True,
 )


### PR DESCRIPTION
Also removed markings on definitions that used to require consent or authorization, as neither feature has been available on the Data Finland dataspace in a long time. Also marked the definitions that required those features as deprecated.
